### PR TITLE
split up groups into affiliated and supporters and made two pages for them

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,6 +32,7 @@
         <ul>
           <li><a href="about.html">About</a></li>
           <li><a href="organizations.html">Organizations</a></li>
+          <li><a href="supporters.html">Supporters</a></li>
           <li><a href="tourdecode.html">Tour de Code</a></li>
           <li><a href="events.html">Events & Resources</a></li>
           <li><a href="codecoffee.html">Code & Coffee</a></li>

--- a/organizations.html
+++ b/organizations.html
@@ -5,55 +5,41 @@ published: true
 
 <div class="content">
 
-            <h1>Affiliated Organizations:</h1>
+      <h1>Affiliated Organizations:</h1>
 
-            <h1>AIGA</h1><p>We're the Washington, DC Chapter of AIGA, the Professional Association for Design. We support the DC creative community!
-            </br><a href="http://www.twitter.com/aigadc">@aigadc</a> // <a href="http://dc.aiga.org">Website</a></p>
+      <h2>DC Web Women</h2><p>A professional organization encouraging women in new media.
+      </br><a href="http://www.twitter.com/dcww">@dcww</a> // <a href="http://www.dcwebwomen.org/">Website</a></p>
 
-            <h1>Code for DC</h1><p>DC chapter of the Code For America CFA brigade - we are volunteer civic hackers working together to solve local issues and help people engage with DC
-            </br><a href="http://www.twitter.com/codefordc">@codefordc</a> // <a href="http://www.meetup.com/Code-for-DC/">Website</a></p>
+      <h2>DC PyLadies</h2><p>The DC chapter of Pyladies, an international group focused on getting more women into Python community and programming.
+      </br><a href="http://www.twitter.com/pyladiesdc">@PyLadiesDC</a> // <a href="http://www.meetup.com/dc-pyladies/">Website</a></p>
 
-            <h1>DC Web Women</h1><p>A professional organization encouraging women in new media.
-            </br><a href="http://www.twitter.com/dcww">@dcww</a> // <a href="http://www.dcwebwomen.org/">Website</a></p>
+      <h2>Georgetown Women Who Code</h2>
 
-            <h1>DC PyLadies</h1><p>The DC chapter of Pyladies, an international group focused on getting more women into Python community and programming.
-            </br><a href="http://www.twitter.com/pyladiesdc">@PyLadiesDC</a> // <a href="http://www.meetup.com/dc-pyladies/">Website</a></p>
+      <h2>Girl Develop It DC</h2><p>Empowering women in DC to learn how to program in a supportive and fun environment.
+      </br><a href="http://www.twitter.com/girldevelopitDC">@girldevelopitDC</a> // <a href="http://www.meetup.com/Girl-Develop-It-DC/">Website</a></p>
 
-            <h1>Girl Develop It DC</h1><p>Empowering women in DC to learn how to program in a supportive and fun environment.
-            </br><a href="http://www.twitter.com/girldevelopitDC">@girldevelopitDC</a> // <a href="http://www.meetup.com/Girl-Develop-It-DC/">Website</a></p>
+      <h2>Hear Me Code</h2><p>Free, beginner-friendly Python coding classes for women, by women
+      </br><a href="http://www.twitter.com/svt827">by Shannon Turner</a> // <a href="http://www.hearmecode.com">Website</a></p>
 
-            <h1>Google Developer Group DC</h1><p>Google Developer Groups (GDGs) are for developers who are interested in Google's developer technology; everything from the Android, App Engine, and Google Chrome platforms, to product APIs like the Maps API,YouTube API and Google Calendar API.
-            </br><a href="http://www.twitter.com/gdevdc">@gdevdc</a> // <a href="http://www.meetup.com/gdg-dc/">Website</a></p>
+      <h2>Ladies Who Code DC</h2><p>Ladies Who Code brings the brightest female minds together to discuss tech, share ideas and innovate via global meetups.
+      </br><a href="http://www.twitter.com/ladieswhocode">@LadiesWhoCode</a> // <a href="http://www.meetup.com/Ladies-Who-Code-Washington-DC/">Website</a></p>
 
-            <h1>Hear Me Code</h1><p>Free, beginner-friendly Python coding classes for women, by women
-            </br><a href="http://www.twitter.com/svt827">by Shannon Turner</a> // <a href="http://www.hearmecode.com">Website</a></p>
+      <h2>Lesbians Who Tech</h2><p>Lesbians Who Tech is a community of queer women in and around tech (and the people who love them).
+      </br><a href="http://www.twitter.com/lesbiantech">@LesbianTech</a> // <a href="http://lesbianswhotech.org/">Website</a></p>
 
-            <h1>Geo DC</h1><p>Talking maps and all things geo here and in person the first Wednesday of every month.
-            </br><a href="http://www.twitter.com/geo_dc">@geo_dc</a> // <a href="http://www.meetup.com/Geo-DC/">Website</a></p>
+      <h2>National Center for Women in Tech</h2><p>Revolutionizing the face of technology by increasing the participation of girls and women.
+      </br><a href="http://www.twitter.com/NCWIT">@NCWIT</a> // <a href="http://www.ncwit.org/">Website</a></p>
 
-            <h1>Ladies Who Code DC</h1><p>Ladies Who Code brings the brightest female minds together to discuss tech, share ideas and innovate via global meetups.
-            </br><a href="http://www.twitter.com/ladieswhocode">@LadiesWhoCode</a> // <a href="http://www.meetup.com/Ladies-Who-Code-Washington-DC/">Website</a></p>
+      <h2>Rails Girls DC</h2><p>Our aim is to give tools and a community for women to understand technology and to build their ideas with Ruby on Rails. We do this by providing a great experiences on building things and make technology more approachable.
+      </br><a href="http://www.twitter.com/railsgirlsdc">@railsgirlsDC</a> // <a href="http://railsgirls.com/dc">Website</a></p>
 
-            <h1>Lesbians Who Tech</h1><p>Lesbians Who Tech is a community of queer women in and around tech (and the people who love them).
-            </br><a href="http://www.twitter.com/lesbiantech">@LesbianTech</a> // <a href="http://lesbianswhotech.org/">Website</a></p>
+      <h2>Tech Lady Mafia</h2>
 
-            <h1>Maptime DC</h1><p>Maptime is, rather literally, time for mapmaking. Our mission is to open the doors of cartographic possibility to anyone interested by creating a time and space for collaborative learning, exploration, and map creation using mapping tools and technologies.
-            </br><a href="http://www.twitter.com/maptimeDC">@maptimeDC</a> // <a href="http://www.meetup.com/Maptime-DC/">Website</a></p>
+      <h2>Women Who Code DC</h2><p>We are focused on providing women with tangible programming skills to expand their career opportunities. We are made up of a lot of study groups that learn anything in the "full stack" of development (aka from the very back end of coding involving networks and security, to the front end involving scripting and styling). Whether you love Python or are trying to learn anything you can - we are a group that allows you to pick and choose whatever fits your learning style!
+      </br><a href="http://www.twitter.com/WomenWhoCodeDC">@WomenWhoCodeDC</a> // <a href="http://www.meetup.com/Women-Who-Code-DC/">Website</a></p>
 
-            <h1>National Center for Women in Tech</h1><p>Revolutionizing the face of technology by increasing the participation of girls and women.
-            </br><a href="http://www.twitter.com/NCWIT">@NCWIT</a> // <a href="http://www.ncwit.org/">Website</a></p>
+      <h2>Women 2.0 City Meetup</h2><p>Women 2.0’s networking event. Our mission is to connect, inspire and advance authentic relationships in the tech ecosystem. We invite not only to founders, but also executives, investors, engineers and creative innovators in tech.
+      </br><a href="http://www.twitter.com/Women2">@Women2</a> // <a href="http://women2.com/city-meetup/crystal-city-2/">Website</a></p>
 
-            <h1>Rails Girls DC</h1><p>Our aim is to give tools and a community for women to understand technology and to build their ideas with Ruby on Rails. We do this by providing a great experiences on building things and make technology more approachable.
-            </br><a href="http://www.twitter.com/railsgirlsdc">@railsgirlsDC</a> // <a href="http://railsgirls.com/dc">Website</a></p>
+</div>
 
-            <h1>Sassy DC</h1><p>Where people in the District gather to talk Sass (the CSS preprocessor)
-            </br><a href="http://www.twitter.com/DCSassMeetup">@DCSassMeetup</a> // <a href="http://sassydc.github.io/">Website</a></p>
-
-            <h1>Web Content Mavens</h1><p>Local networking and information exchange group focused on web content, content strategy and content management systems (CMS).
-            </br><a href="http://www.twitter.com/wcmdc">@wcmdc</a> // <a href="http://www.meetup.com/webcontentmavens/">Website</a></p>
-
-            <h1>Women Who Code DC</h1><p>We are focused on providing women with tangible programming skills to expand their career opportunities. We are made up of a lot of study groups that learn anything in the "full stack" of development (aka from the very back end of coding involving networks and security, to the front end involving scripting and styling). Whether you love Python or are trying to learn anything you can - we are a group that allows you to pick and choose whatever fits your learning style!
-            </br><a href="http://www.twitter.com/WomenWhoCodeDC">@WomenWhoCodeDC</a> // <a href="http://www.meetup.com/Women-Who-Code-DC/">Website</a></p>
-
-            <h1>Women 2.0 City Meetup</h1><p>Women 2.0’s networking event. Our mission is to connect, inspire and advance authentic relationships in the tech ecosystem. We invite not only to founders, but also executives, investors, engineers and creative innovators in tech.
-            </br><a href="http://www.twitter.com/Women2">@Women2</a> // <a href="http://women2.com/city-meetup/crystal-city-2/">Website</a></p>

--- a/supporters.html
+++ b/supporters.html
@@ -1,0 +1,38 @@
+---
+layout: main
+published: true
+---
+
+<div class="content">
+
+      <h1>Supportive Organizations:</h1>
+
+      <h2>AIGA</h2><p>We're the Washington, DC Chapter of AIGA, the Professional Association for Design. We support the DC creative community!
+      </br><a href="http://www.twitter.com/aigadc">@aigadc</a> // <a href="http://dc.aiga.org">Website</a></p>
+
+      <h2>Code for DC</h2><p>DC chapter of the Code For America CFA brigade - we are volunteer civic hackers working together to solve local issues and help people engage with DC
+      </br><a href="http://www.twitter.com/codefordc">@codefordc</a> // <a href="http://www.meetup.com/Code-for-DC/">Website</a></p>
+
+      <h2>Code for Progress</h2>
+
+      <h2>CommunityRED</h2>
+
+      <h2>General Assembly</h2>
+
+      <h2>Google Developer Group DC</h2><p>Google Developer Groups (GDGs) are for developers who are interested in Google's developer technology; everything from the Android, App Engine, and Google Chrome platforms, to product APIs like the Maps API,YouTube API and Google Calendar API.
+      </br><a href="http://www.twitter.com/gdevdc">@gdevdc</a> // <a href="http://www.meetup.com/gdg-dc/">Website</a></p>
+
+      <h2>Geo DC</h2><p>Talking maps and all things geo here and in person the first Wednesday of every month.
+      </br><a href="http://www.twitter.com/geo_dc">@geo_dc</a> // <a href="http://www.meetup.com/Geo-DC/">Website</a></p>
+
+      <h2>Maptime DC</h2><p>Maptime is, rather literally, time for mapmaking. Our mission is to open the doors of cartographic possibility to anyone interested by creating a time and space for collaborative learning, exploration, and map creation using mapping tools and technologies.
+      </br><a href="http://www.twitter.com/maptimeDC">@maptimeDC</a> // <a href="http://www.meetup.com/Maptime-DC/">Website</a></p>
+
+      <h2>Sassy DC</h2><p>Where people in the District gather to talk Sass (the CSS preprocessor)
+      </br><a href="http://www.twitter.com/DCSassMeetup">@DCSassMeetup</a> // <a href="http://sassydc.github.io/">Website</a></p>
+
+      <h2>Web Content Mavens</h2><p>Local networking and information exchange group focused on web content, content strategy and content management systems (CMS).
+      </br><a href="http://www.twitter.com/wcmdc">@wcmdc</a> // <a href="http://www.meetup.com/webcontentmavens/">Website</a></p>
+
+</div>
+


### PR DESCRIPTION
We could potentially change the wording?

I also went through and added the groups that I noticed were missing, but I wasn't sure where to grab group descriptions, so if we are cool with splitting this way - I can go through and reach out to the groups that don't have a description/links to twitter and website and put that in as well!
