### PR TITLE
Updated Women Who Code DC Front End Hack Night (FEHN) events

### DIFF
--- a/tourdecode.html
+++ b/tourdecode.html
@@ -80,7 +80,7 @@ published: true
                   <td>Mon 10/5</td>
                   <td><a href="http://www.meetup.com/Women-Who-Code-DC/events/223779220/">Front End - Hack Night</a></td>
                   <td>6:30-8:30pm</td>
-                  <td>TBD</td>
+                  <td>iStrategyLabs</td>
                   <td>Women Who Code DC</td>
               </tr>
 
@@ -200,7 +200,7 @@ published: true
                   <td>Mon 10/19</td>
                   <td><a href="http://www.meetup.com/Women-Who-Code-DC/events/223779227/">Front End - Hack Night</a></td>
                   <td>6:30-8:30pm</td>
-                  <td>TBD</td>
+                  <td>ECMC | 1015 7th St NW</td>
                   <td>Women Who Code DC</td>
               </tr>
 
@@ -277,7 +277,7 @@ published: true
                   <td>Mon 10/26</td>
                   <td><a href="http://www.meetup.com/Women-Who-Code-DC/events/223779229/">Front End - Hack Night</a></td>
                   <td>6:30-8:30pm</td>
-                  <td>TBD</td>
+                  <td>Socrata | 1150 17th St NW</td>
                   <td>Women Who Code DC</td>
               </tr>
               


### PR DESCRIPTION
Updated Women Who Code DC Front End Hack Night (FEHN) events with host name and address information.
