### PR TITLE
Updated event host and location for 10/26 WWCDC Front End Hack Night

### DIFF
--- a/tourdecode.html
+++ b/tourdecode.html
@@ -289,7 +289,7 @@ published: true
                   <td>Mon 10/26</td>
                   <td><a href="http://www.meetup.com/Women-Who-Code-DC/events/223779229/">Front End - Hack Night</a></td>
                   <td>6:30-8:30pm</td>
-                  <td>Socrata | 1150 17th St NW</td>
+                  <td>RepEquity | 1211 Conneticut Ave NW #250</td>
                   <td>Women Who Code DC</td>
               </tr>
               
@@ -311,7 +311,7 @@ published: true
               </tr>
 
               <tr>
-                  <td>Weds 10/81</td>
+                  <td>Weds 10/28</td>
                   <td><a href="http://www.meetup.com/Women-Who-Code-DC/events/gnsnklytnblc/">Ruby on Rails - Hack Night</a></td>
                   <td>6:30-8:30pm</td>
                   <td>Canvas</td>


### PR DESCRIPTION
Updated event host and location for Women Who Code DC (WWCDC) Front End Hack night for October 26th. Also corrected typo with date of WWCDC Ruby hack night on October 28th
