### PR TITLE
Fixes typo on 2016 awards page

### DIFF
--- a/dcftawards_2016.html
+++ b/dcftawards_2016.html
@@ -177,7 +177,7 @@ published: true
             <strong>Mollie Bates</strong>, Consumer Financial Protection Bureau
         </li>
         <li>
-            <strong>Mollie Ruskin</strong>, U.S. Digital Srevices
+            <strong>Mollie Ruskin</strong>, U.S. Digital Service
         </li>
         <li>
             <strong>Ngan Hoang</strong>, Vox Media


### PR DESCRIPTION
Changes `U.S. Digital Srevices` to `U.S. Digital Service` on 2016 DCFemTech Awards page.

Per [USDS Twitter](https://twitter.com/USDS) and [official website](https://www.whitehouse.gov/digital/united-states-digital-service) the singular service appears to be preferred over plural services.

/cc @jackiekazil @ShanaGlenzer 
